### PR TITLE
Enable secret scanning for all repos

### DIFF
--- a/otterdog/eclipse-wildwebdeveloper.jsonnet
+++ b/otterdog/eclipse-wildwebdeveloper.jsonnet
@@ -19,8 +19,6 @@ orgs.newOrg('eclipse-wildwebdeveloper') {
       description: "Simple and productive Web Development Tools in the Eclipse IDE",
       has_discussions: true,
       homepage: "https://projects.eclipse.org/projects/tools.wildwebdeveloper",
-      secret_scanning: "disabled",
-      secret_scanning_push_protection: "disabled",
       topics+: [
         "hacktoberfest"
       ],


### PR DESCRIPTION
We (security team at EF: https://www.eclipse.org/security/team/) would like to enable secret scanning for all of the repos of eclipse projects hosted on GitHub. For that purpose we suggest changes to the configuration that the project leads can review.